### PR TITLE
Ensure false is returned when file_get_contents() fails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cover
 .idea
 vendor
 composer.lock
+/composer.phar


### PR DESCRIPTION
- Ensure false is returned when file_get_contents() is mocked to fail.
- Stabilize test suite under Windows.
- Make sure stream_open() returns a boolean and not a resource.